### PR TITLE
Upgrade to Python 3, Ubuntu 18.04, Django 2.2.16, and other tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 MAINTAINER Dockerfiles
 
@@ -9,17 +9,19 @@ RUN apt-get update && \
     apt-get upgrade -y && \ 
     apt-get install -y \
         git \
-        python \
-        python-dev \
+        python3 \
+        python3-dev \
         libpq-dev \
         python-setuptools \
-        python-pip \
+        python3-pip \
         nginx \
         supervisor \
         libmysqlclient-dev \
         sqlite3 && \
-        pip install -U pip setuptools && \
-        rm -rf /var/lib/apt/lists/*
+    rm /usr/bin/python && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    pip3 install -U pip setuptools && \
+    rm -rf /var/lib/apt/lists/*
 
 # install uwsgi
 RUN pip install uwsgi
@@ -36,8 +38,6 @@ COPY supervisor-app.conf /etc/supervisor/conf.d/
 
 COPY requirements.txt /home/docker/code/SpearmintServer/
 RUN pip install -r /home/docker/code/SpearmintServer/requirements.txt
-COPY requirements2.txt /home/docker/code/SpearmintServer/
-RUN pip --no-cache-dir install -r /home/docker/code/SpearmintServer/requirements2.txt
 
 # add (the rest of) our code
 COPY . /home/docker/code/
@@ -46,7 +46,7 @@ ENV HOME /home/docker/code/SpearmintServer/
 WORKDIR $HOME
 
 RUN python manage.py collectstatic --noinput
-RUN pip install git+http://github.com/acil-bwh/Spearmint.git@develop
+RUN pip install git+http://github.com/acil-bwh/Spearmint.git@python3-migration
 RUN python setup.py install
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ ENV HOME /home/docker/code/SpearmintServer/
 WORKDIR $HOME
 
 RUN python manage.py collectstatic --noinput
-RUN pip install git+http://github.com/acil-bwh/Spearmint.git@python3-migration
+RUN pip install git+http://github.com/acil-bwh/Spearmint.git@develop
 RUN python setup.py install
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-Django==1.8.5
-MySQL-Python==1.2.5
+Django==2.2.16
+mysqlclient==2.0.1
 python-dateutil>=1.5
-django-oauth-toolkit==0.9.0
-django-cors-headers==1.1.0
-numpy==1.12.0
-pymongo==3.4.0
+django-oauth-toolkit==1.3.2
+django-cors-headers==3.5.0
+numpy==1.18.1
+pymongo==3.11.0
 requests==2.13.0
-weave==0.15.0


### PR DESCRIPTION
Also removed the requirements2.txt since corresponding Spearmint (Python 3 version - already updated in develop branch) does not have its dependency on the "weave" package.